### PR TITLE
fix: set root_path to v1 in order correcly serve the openapi file

### DIFF
--- a/mock/src/itc_api.py
+++ b/mock/src/itc_api.py
@@ -19,7 +19,7 @@ from .models import (
 )
 from .init_dynamodb import db
 
-app = FastAPI()
+app = FastAPI(root_path="/v1")
 
 
 objectEvent = APIRouter(prefix="/objectEvents", tags=["ObjectEvent"])


### PR DESCRIPTION
This is a minor fix that lets the redoc and docs pages to be rendered properly